### PR TITLE
src: Update glyphs.h includes so that they don't use relatives includes

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -22,7 +22,7 @@
 
 #include "ui.h"
 #include <stdbool.h>
-#include "../glyphs.h"
+#include "glyphs.h"
 #include "../main.h"
 #include "../crypto/waves.h"
 #include "transactions/transfer.h"


### PR DESCRIPTION
This is necessary as this file is automatically generated and it's generation location is going to change